### PR TITLE
Day 65: Slit Scan Camera

### DIFF
--- a/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/README.md
+++ b/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/README.md
@@ -1,0 +1,21 @@
+# Day 65 – Slit Scan Camera
+
+This sketch implements a slit-scan camera effect using live webcam input.
+
+Instead of displaying full frames, the program extracts a single vertical
+slice from each frame and draws it sequentially across the canvas. Over
+time, the horizontal axis represents time, creating stretched and warped
+visuals of motion.
+
+## Concept
+
+Slit-scan imaging transforms time into space. Motion is no longer shown
+as discrete frames but as continuous spatial distortion, revealing
+patterns invisible to normal video playback.
+
+## Techniques Used
+
+- getUserMedia  (webcam access)
+- Offscreen canvas pixel extraction
+- Time-based image accumulation
+- Canvas drawImage slicing

--- a/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/index.html
+++ b/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Day 65 - Slit Scan Camera</title>
+  <style>
+    body {
+      margin: 0;
+      background: black;
+      overflow: hidden;
+    }
+    canvas {
+      display: block;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <script src="sketch.js"></script>
+</body>
+</html>

--- a/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/sketch.js
+++ b/03_PIXELS_AND_SOUND/day-65-slit-scan-camera/sketch.js
@@ -1,0 +1,82 @@
+// ==================================================
+// Slit Scan Camera
+// ==================================================
+
+/*
+  This sketch captures webcam frames and extracts
+  a single vertical slice from each frame.
+
+  Each slice is drawn sequentially across the canvas,
+  turning time into a horizontal spatial dimension.
+*/
+
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
+
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+// Webcam video
+const video = document.createElement("video");
+video.autoplay = true;
+
+navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+  video.srcObject = stream;
+});
+
+// Offscreen canvas to read pixels
+const buffer = document.createElement("canvas");
+const bctx = buffer.getContext("2d");
+
+let xOffset = 0; // current slit position
+
+// =================================================
+// Animation Loop
+// ==================================================
+
+function animate() {
+  if (video.videoWidth === 0) {
+    requestAnimationFrame(animate);
+    return;
+  }
+
+  // Match buffer to video size
+  buffer.width = video.videoWidth;
+  buffer.height = video.videoHeight;
+
+  // Draw current webcam frame
+  bctx.drawImage(video, 0, 0);
+
+  /*
+    Extract a vertical slice from the center
+    of the webcam frame.
+  */
+  const sliceX = Math.floor(video.videoWidth / 2);
+  const sliceWidth = 1;
+
+  // Draw the slice stretched to canvas height
+  ctx.drawImage(
+    buffer,
+    sliceX,
+    0,
+    sliceWidth,
+    video.videoHeight,
+    xOffset,
+    0,
+    1,
+    canvas.height
+  );
+
+  // Advance horizontal position
+  xOffset++;
+
+  // When canvas is full, start over
+  if (xOffset >= canvas.width) {
+    xOffset = 0;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }
+
+  requestAnimationFrame(animate);
+}
+
+animate();


### PR DESCRIPTION
This pull request restores and adds the Day 65 slit-scan camera sketch under the Pixels and Sound section.
The implementation captures a single vertical slice from each webcam frame and accumulates it across time, transforming motion into spatial distortion using the Canvas API.
